### PR TITLE
🏗️ infra: minio s3 storage config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,10 +26,6 @@ APP_URL=http://localhost:${WEB_SERVER_PORT_LOCAL}
 # APP_DEBUG=true
 # APP_URL=http://localhost:${WEB_SERVER_PORT_PROD_LOCAL}
 
-
-WEB_SERVER_PORT_LOCAL=9090
-WEB_SERVER_PORT_PROD_LOCAL=9091
-
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug
@@ -95,6 +91,7 @@ STAGING_HTTP_PASSWORD=set_a_password
 
 # Coolify environment example:
 
+
 ## Production:
 
 # APP_DEBUG=false
@@ -107,6 +104,17 @@ STAGING_HTTP_PASSWORD=set_a_password
 # DB_PASSWORD=password_production
 # DB_ROOT_PASSWORD=password_root_production
 # DB_USERNAME=emuseu_user
+
+### Storage (MinIO/S3): set FILESYSTEM_DISK=s3 and fill AWS_* from your MinIO service in Coolify
+# FILESYSTEM_DISK=s3
+# AWS_ACCESS_KEY_ID=
+# AWS_SECRET_ACCESS_KEY=
+# AWS_DEFAULT_REGION=us-east-1
+# AWS_BUCKET=e-museu-production
+# AWS_ENDPOINT=https://minio-xxx.your-server.sslip.io
+# AWS_USE_PATH_STYLE_ENDPOINT=true
+# AWS_URL=https://minio-xxx.your-server.sslip.io/e-museu-production
+
 
 
 ## Staging (HTTP Basic Auth: set STAGING_HTTP_USER and STAGING_HTTP_PASSWORD in Coolify app env):
@@ -123,3 +131,13 @@ STAGING_HTTP_PASSWORD=set_a_password
 # DB_PASSWORD=password_staging
 # DB_ROOT_PASSWORD=password_root_staging
 # DB_USERNAME=emuseu_user
+
+### Storage (MinIO/S3): set FILESYSTEM_DISK=s3 and fill AWS_* from your MinIO service in Coolify
+# FILESYSTEM_DISK=s3
+# AWS_ACCESS_KEY_ID=
+# AWS_SECRET_ACCESS_KEY=
+# AWS_DEFAULT_REGION=us-east-1
+# AWS_BUCKET=e-museu-staging
+# AWS_ENDPOINT=https://minio-xxx.your-server.sslip.io
+# AWS_USE_PATH_STYLE_ENDPOINT=true
+# AWS_URL=https://minio-xxx.your-server.sslip.io/e-museu-staging

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -36,13 +36,26 @@ return [
             'throw' => false,
         ],
 
-        'public' => [
-            'driver' => 'local',
-            'root' => storage_path('app/public'),
-            'url' => env('APP_URL').'/storage',
-            'visibility' => 'public',
-            'throw' => false,
-        ],
+        'public' => env('FILESYSTEM_DISK') === 's3'
+            ? [
+                'driver' => 's3',
+                'key' => env('AWS_ACCESS_KEY_ID'),
+                'secret' => env('AWS_SECRET_ACCESS_KEY'),
+                'region' => env('AWS_DEFAULT_REGION'),
+                'bucket' => env('AWS_BUCKET'),
+                'url' => env('AWS_URL'),
+                'endpoint' => env('AWS_ENDPOINT'),
+                'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
+                'visibility' => 'public',
+                'throw' => false,
+            ]
+            : [
+                'driver' => 'local',
+                'root' => storage_path('app/public'),
+                'url' => env('APP_URL').'/storage',
+                'visibility' => 'public',
+                'throw' => false,
+            ],
 
         's3' => [
             'driver' => 's3',


### PR DESCRIPTION
# 🏗️ Add MinIO/S3 storage for staging and production

### Related Issue: #11

## 🔄 Change Overview

### ✨ Summary of changes:
- Make `public` disk in `config/filesystems.php` conditional: when `FILESYSTEM_DISK=s3`, use S3/MinIO (AWS_* env vars); otherwise keep local storage so dev stays unchanged.
- Extend `.env.example` Coolify section with Production and Staging examples including storage vars (`FILESYSTEM_DISK`, `AWS_*`) for MinIO so deploy only needs env config in Coolify.
- Local remains on local disk; staging and production on Coolify use MinIO when the listed env vars are set.

### 🏷️ Type of change:
<!-- Select one or two that apply -->
- **Infra**

### ⏳ Time spent:
- **1 HOUR** (approximate)

### 📝 Additional notes:
<!-- Any extra context, screenshots, or information for the reviewer -->
- N/A

## ✅ PR Checklist
- [x] No sensitive information (passwords, API keys, secrets) exposed
- [x] All tests run and pass successfully (unit, e2e, lint, etc.)
- [x] Code compiles and runs without errors
- [x] Tests and documentation updated or added if applicable
- [x] Removed unnecessary comments, debug statements and dev artifacts
- [x] Related issues, labels, and PR links established; PR title OK
