### PR TITLE
♻️ refactor: controllers part 3

### DIFF
--- a/app/Actions/Catalog/StoreItemContributionAction.php
+++ b/app/Actions/Catalog/StoreItemContributionAction.php
@@ -2,17 +2,15 @@
 
 namespace App\Actions\Catalog;
 
-use App\Enums\Collaborator\CollaboratorRole;
 use App\Models\Catalog\Item;
 use App\Models\Catalog\ItemComponent;
 use App\Models\Collaborator\Collaborator;
+use App\Services\Catalog\ExtraService;
 use App\Services\Catalog\ItemImagesService;
 use App\Services\Catalog\ItemService;
 use App\Services\Catalog\ItemTagService;
-use App\Services\Catalog\ExtraService;
 use App\Services\Collaborator\CollaboratorService;
 use App\Services\Taxonomy\TagService;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\DB;
 
@@ -30,14 +28,22 @@ class StoreItemContributionAction
 
     /**
      * Store a contributed item (public contribution flow).
-     * Resolves collaborator, creates item, images, tags, extras and components.
+     * Resolves collaborator and creates item, images, tags, extras and components.
      *
-     * @param  array<string, mixed>                 $collaboratorData
-     * @param  array<string, mixed>                 $itemData
-     * @param  array<int, array<string, mixed>>     $tags
-     * @param  array<int, array<string, mixed>>     $extras
-     * @param  array<int, array<string, mixed>>     $components
-     * @param  array<int, UploadedFile>|null        $galleryImages
+     * @param  array<string, mixed>  $collaboratorData  Collaborator data validated by the
+     *                                                  request (e.g. name, contact).
+     * @param  array<string, mixed>  $itemData          Item data (name, category_id,
+     *                                                  description, history, detail, date,
+     *                                                  validation, etc.).
+     * @param  array<int, array<string, mixed>>  $tags  Tag data validated by the request.
+     * @param  array<int, array<string, mixed>>  $extras  Extra data (e.g. type, value, etc.).
+     * @param  array<int, array<string, mixed>>  $components  Components identified by
+     *                                                        category and name.
+     * @param  array<int, UploadedFile>|null  $galleryImages
+     * @return array{
+     *     status: 'ok'|'internal_blocked'|'collaborator_blocked',
+     *     item?: Item
+     * }
      */
     public function handle(
         array $collaboratorData,
@@ -47,10 +53,14 @@ class StoreItemContributionAction
         array $components,
         ?UploadedFile $coverImage,
         ?array $galleryImages = null
-    ): RedirectResponse {
-        $collaborator = $this->resolveCollaboratorForContribution($collaboratorData);
-        if ($collaborator instanceof RedirectResponse) {
-            return $collaborator;
+    ): array {
+        $resolution = $this->resolveCollaboratorForContribution($collaboratorData);
+        if ($resolution['status'] !== 'ok') {
+            return ['status' => $resolution['status']];
+        }
+        $collaborator = $resolution['collaborator'];
+        if (! $collaborator instanceof Collaborator) {
+            return ['status' => 'internal_blocked'];
         }
 
         if ($coverImage) {
@@ -68,26 +78,42 @@ class StoreItemContributionAction
         $this->extraService->createForItem($item, $collaborator, $extras);
         $this->attachComponentsToItem($item, $components);
 
-        return redirect()->route('items.create')->with('success', __('app.catalog.item.contribution_success'));
+        return [
+            'status' => 'ok',
+            'item' => $item,
+        ];
     }
 
     /**
-     * Resolve collaborator for contribution; return redirect with errors if not allowed.
+     * Resolve collaborator for contribution.
      *
      * @param  array<string, mixed>  $collaboratorData
-     * @return Collaborator|RedirectResponse
+     * @return array{
+     *     status: 'ok'|'internal_blocked'|'collaborator_blocked',
+     *     collaborator: Collaborator|null
+     * }
      */
-    private function resolveCollaboratorForContribution(array $collaboratorData): Collaborator|RedirectResponse
+    private function resolveCollaboratorForContribution(array $collaboratorData): array
     {
         $collaborator = $this->collaboratorService->resolveOrCreateCollaborator($collaboratorData);
-        if ($collaborator->role === CollaboratorRole::INTERNAL) {
-            return back()->withErrors(['contact' => __('app.collaborator.contact_reserved_for_internal')]);
-        }
-        if ($collaborator->blocked === true) {
-            return back()->withErrors(['blocked' => __('app.collaborator.blocked_from_registering')]);
+        if ($collaborator->role === \App\Enums\Collaborator\CollaboratorRole::INTERNAL) {
+            return [
+                'status' => 'internal_blocked',
+                'collaborator' => null,
+            ];
         }
 
-        return $collaborator;
+        if ($collaborator->blocked === true) {
+            return [
+                'status' => 'collaborator_blocked',
+                'collaborator' => null,
+            ];
+        }
+
+        return [
+            'status' => 'ok',
+            'collaborator' => $collaborator,
+        ];
     }
 
     /**
@@ -107,7 +133,6 @@ class StoreItemContributionAction
             $this->itemImagesService->storeCoverImage($item, $coverImage);
         }
         $this->itemImagesService->storeGalleryImages($item, $galleryImages);
-        $item->normalizeSingleCover();
 
         return $item;
     }
@@ -124,9 +149,9 @@ class StoreItemContributionAction
 
         return DB::transaction(function () use ($itemData): Item {
             $item = Item::create($itemData);
-            $updateData = $itemData;
-            $updateData['identification_code'] = $this->itemService->createIdentificationCode($item);
-            $item->update($updateData);
+            $item->update([
+                'identification_code' => $this->itemService->createIdentificationCode($item),
+            ]);
 
             return $item;
         });
@@ -144,6 +169,11 @@ class StoreItemContributionAction
                 ->where('name', '=', $componentItemData['name'])
                 ->first();
             if (! $component) {
+                logger()->info('Component item not found for contribution', [
+                    'item_id' => $item->id,
+                    'component_category_id' => $componentItemData['category_id'] ?? null,
+                    'component_name' => $componentItemData['name'] ?? null,
+                ]);
                 continue;
             }
             $componentItemData['component_id'] = $component->id;

--- a/app/Http/Controllers/Admin/Catalog/AdminItemController.php
+++ b/app/Http/Controllers/Admin/Catalog/AdminItemController.php
@@ -125,7 +125,7 @@ class AdminItemController extends AdminBaseController
         ItemImagesService $itemImagesService,
         LockService $lockService
     ): RedirectResponse {
-        $this->requireUnlocked($item, $lockService);
+        $lockService->requireUnlocked($item);
         $itemImagesService->deleteImage($item, $image);
 
         return redirect()->route('admin.items.edit', $item)->with('success', __('app.catalog.item_image.deleted'));

--- a/app/Http/Controllers/Catalog/ExtraController.php
+++ b/app/Http/Controllers/Catalog/ExtraController.php
@@ -22,10 +22,20 @@ class ExtraController extends Controller
     ): RedirectResponse {
         $validatedData = $itemContributionValidator->validateSingleExtra($request);
 
-        return $extraService->storeSingleExtra(
+        $result = $extraService->storeSingleExtra(
             $collaboratorService,
             $validatedData['collaborator'],
             $validatedData['extra']
         );
+
+        if ($result['status'] === 'internal_blocked') {
+            return back()->withErrors(['contact' => __('app.collaborator.contact_reserved_for_internal')]);
+        }
+
+        if ($result['status'] === 'collaborator_blocked') {
+            return back()->withErrors(['blocked' => __('app.collaborator.blocked_from_registering')]);
+        }
+
+        return back()->with('success', __('app.catalog.extra.contribution_success'));
     }
 }

--- a/app/Http/Controllers/Catalog/ItemController.php
+++ b/app/Http/Controllers/Catalog/ItemController.php
@@ -54,7 +54,7 @@ class ItemController extends Controller
 
         $galleryFiles = $itemImagesService->filterValidGalleryFiles($request->file('gallery_images'));
 
-        return $storeItemContributionAction->handle(
+        $result = $storeItemContributionAction->handle(
             $validatedData['collaborator'],
             $validatedData['item'],
             $validatedData['tags'],
@@ -63,6 +63,16 @@ class ItemController extends Controller
             $request->file('cover_image'),
             $galleryFiles ?: null
         );
+
+        if ($result['status'] === 'internal_blocked') {
+            return back()->withErrors(['contact' => __('app.collaborator.contact_reserved_for_internal')]);
+        }
+
+        if ($result['status'] === 'collaborator_blocked') {
+            return back()->withErrors(['blocked' => __('app.collaborator.blocked_from_registering')]);
+        }
+
+        return redirect()->route('items.create')->with('success', __('app.catalog.item.contribution_success'));
     }
 
     public function show(

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -2,14 +2,14 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Catalog\Item;
+use App\Services\Catalog\ItemService;
 use Illuminate\View\View;
 
 class HomeController extends Controller
 {
-    public function index(): View
+    public function index(ItemService $itemService): View
     {
-        $items = Item::with('coverImage')->where('validation', true)->inRandomOrder()->take(5)->get();
+        $items = $itemService->getRandomValidatedItemsForHome();
 
         return view('home', compact('items'));
     }

--- a/app/Services/Catalog/ExtraService.php
+++ b/app/Services/Catalog/ExtraService.php
@@ -10,7 +10,6 @@ use App\Services\Collaborator\CollaboratorService;
 use App\Support\AdminIndexQueryBuilder;
 use App\Support\AdminIndexConfig;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
 class ExtraService
@@ -74,26 +73,29 @@ class ExtraService
     }
 
     /**
-     * @param  array<string, mixed>  $collaboratorData
-     * @param  array<string, mixed>  $extraData
+     * Handle single extra creation from public contribution.
+     *
+     * @param  array<string, mixed>  $collaboratorData Collaborator data validated by the request.
+     * @param  array<string, mixed>  $extraData        Extra data validated by the request.
+     * @return array{status: 'ok'|'internal_blocked'|'collaborator_blocked'}
      */
     public function storeSingleExtra(
         CollaboratorService $collaboratorService,
         array $collaboratorData,
         array $extraData
-    ): RedirectResponse {
+    ): array {
         $collaborator = $collaboratorService->resolveOrCreateCollaborator($collaboratorData);
 
         if ($collaborator->role === CollaboratorRole::INTERNAL) {
-            return back()->withErrors(['contact' => __('app.collaborator.contact_reserved_for_internal')]);
+            return ['status' => 'internal_blocked'];
         }
 
         if ($collaborator->blocked === true) {
-            return back()->withErrors(['blocked' => __('app.collaborator.blocked_from_registering')]);
+            return ['status' => 'collaborator_blocked'];
         }
 
         $this->create($extraData, $collaborator);
 
-        return back()->with('success', __('app.catalog.extra.contribution_success'));
+        return ['status' => 'ok'];
     }
 }

--- a/app/Services/Catalog/ItemImagesService.php
+++ b/app/Services/Catalog/ItemImagesService.php
@@ -42,11 +42,12 @@ class ItemImagesService
 
     public function processCoverImage(Item $item, AdminUpdateItemRequest $request): void
     {
-        if ($request->image) {
+        $coverFile = $request->file('image');
+        if ($coverFile instanceof UploadedFile && $coverFile->isValid()) {
             /** @var \Illuminate\Support\Collection<int, ItemImage> $currentCovers */
             $currentCovers = $item->images()->where('type', 'cover')->get();
             $currentCovers->each(fn (ItemImage $img) => $this->deleteItemImageFromStorage($img));
-            $this->storeCoverImage($item, $request->image);
+            $this->storeCoverImage($item, $coverFile);
             return;
         }
         if ($request->filled('set_cover_image_id')) {
@@ -58,7 +59,8 @@ class ItemImagesService
     {
         $galleryFiles = $request->file('gallery_images');
         if (is_array($galleryFiles)) {
-            $this->storeGalleryImages($item, $galleryFiles);
+            $validGalleryFiles = $this->filterValidGalleryFiles($galleryFiles);
+            $this->storeGalleryImages($item, $validGalleryFiles);
         }
     }
 
@@ -87,10 +89,16 @@ class ItemImagesService
         $path = ItemImage::buildPath($item, $ext);
         $contents = $file->get();
         if ($contents === false) {
+            report(new RuntimeException(sprintf(
+                'Failed to read uploaded cover image contents for item ID %s',
+                (string) $item->id
+            )));
+
             throw new RuntimeException(__('app.catalog.item.upload_read_failed'));
         }
         Storage::disk('public')->put($path, $contents);
         $item->images()->create(['path' => $path, 'type' => 'cover', 'sort_order' => 0]);
+        $item->normalizeSingleCover();
     }
 
     /**
@@ -115,6 +123,7 @@ class ItemImagesService
             Storage::disk('public')->put($path, $contents);
             $item->images()->create(['path' => $path, 'type' => 'gallery', 'sort_order' => ++$maxOrder]);
         }
+        $item->normalizeSingleCover();
     }
 
     public function deleteAllImagesForItem(Item $item): void
@@ -143,7 +152,9 @@ class ItemImagesService
      */
     public function deleteImage(Item $item, ItemImage $image): void
     {
-        if ($image->item_id !== (int) $item->id) {
+        if ((int) $image->item_id !== (int) $item->id) {
+            report(new NotFoundHttpException('Image does not belong to the given item.'));
+
             throw new NotFoundHttpException();
         }
         $this->deleteItemImageFromStorage($image);

--- a/app/Services/Catalog/ItemService.php
+++ b/app/Services/Catalog/ItemService.php
@@ -85,6 +85,20 @@ class ItemService
     }
 
     /**
+     * Random validated items for the public home page carousel.
+     *
+     * @return Collection<int, Item>
+     */
+    public function getRandomValidatedItemsForHome(int $limit = 5): Collection
+    {
+        return Item::with('coverImage')
+            ->where('validation', true)
+            ->inRandomOrder()
+            ->take($limit)
+            ->get();
+    }
+
+    /**
      * @return Collection<int, Item>
      */
     public function getValidatedNamesForComponentAutocomplete(string $query, string $categoryId): Collection
@@ -102,7 +116,7 @@ class ItemService
 
     public function countValidatedByNameAndCategory(string $name, string $categoryId): int
     {
-        return Item::where('category_id', 'LIKE', $categoryId)
+        return Item::where('category_id', $categoryId)
             ->where('name', 'LIKE', $name)
             ->where('validation', true)
             ->count();

--- a/app/Services/Taxonomy/TagService.php
+++ b/app/Services/Taxonomy/TagService.php
@@ -101,7 +101,7 @@ class TagService
 
     public function countValidatedByNameAndCategory(string $name, string $categoryId): int
     {
-        return Tag::where('tag_category_id', 'LIKE', $categoryId)
+        return Tag::where('tag_category_id', $categoryId)
             ->where('name', 'LIKE', $name)
             ->where('validation', true)
             ->count();

--- a/run
+++ b/run
@@ -355,6 +355,26 @@ function all-tests {
   ./run prettier-check
 }
 
+function all-fix {
+  set -e
+  echo "===="
+  echo ">> Running PHP Code Beautifier and Fixer (phpcbf)..."
+  echo "===="
+  ./run phpcbf
+  echo "===="
+  echo ">> Running Laravel Pint (PHP code style fixer)..."
+  echo "===="
+  ./run pint
+  echo "===="
+  echo ">> Running ESLint with auto-fix..."
+  echo "===="
+  ./run eslint-fix
+  echo "===="
+  echo ">> Running Prettier (format JS/SASS/JSON)..."
+  echo "===="
+  ./run prettier
+}
+
 function ps {
   docker compose -f "$(get_compose_file)" ps "${@}"
 }
@@ -620,6 +640,7 @@ function help {
   echo "  prettier-check   - Check if files are formatted correctly (without modifying)"
   echo "  prettier-check <path> - Check specific path formatting"
   echo "  all-tests          - Run all checks (test, phpcs, pint-test, phpmd, phpstan, phpcpd, eslint, prettier-check)"
+  echo "  all-fix           - Run all auto-fix tools (phpcbf, pint, eslint-fix, prettier)"
   echo "  simulate-ci        - Simulate complete CI pipeline (runs all CI jobs)"
   echo "  simulate-ci -y     - Simulate CI pipeline without confirmation"
   echo ""


### PR DESCRIPTION
# Controllers Part 3
<!-- Put the emoji related to the type and use Title Case or Sentence case for the issue title -->

### Related Issue: #36 
<!-- Use: "Related Issue: N/A" if no issue -->

## 🔄 Change Overview

### ✨ Summary of changes:
<!-- Briefly describe what was done and why, preferably in bullet points -->
```md
- **StoreItemContributionAction**
  - Action now returns a small domain result array (`status` + optional `item`) instead of `RedirectResponse`.
  - Collaborator resolution returns a status + optional `Collaborator`, with guards to ensure non-null collaborators.
  - Item creation transaction only updates `identification_code`, and image normalization is delegated to `ItemImagesService`.
  - Added logging when component items are not found and improved PHPDoc/type hints.

- **Controllers**
  - `ItemController::store()` and `ExtraController::store()` now interpret service/action status and handle all redirects and error flashes in the controller layer.
  - `AdminItemController::destroyImage()` now correctly calls `$lockService->requireUnlocked($item)`.
  - `HomeController::index()` now uses `ItemService::getRandomValidatedItemsForHome()` instead of querying `Item` directly.

- **Services**
  - `ExtraService::storeSingleExtra()` returns a status array instead of performing redirects.
  - `ItemService::getRandomValidatedItemsForHome()` added; count-by-category methods now use exact ID comparison where appropriate.
  - `ItemImagesService` now:
    - Uses `UploadedFile` checks for cover/gallery images.
    - Normalizes the item’s cover image inside `storeCoverImage()` / `storeGalleryImages()`.
    - Logs and throws on upload read failures and mismatched image ownership.

- **Tooling**
  - `run` script gained `all-fix`, which runs `phpcbf`, `pint`, `eslint-fix`, and `prettier` in sequence.
```

### 🏷️ Type of change:
<!-- Select one or two that apply -->
- **REFACTOR**

### ⏳ Time spent:
- **2 HOURS** (approximate)

### 📝 Additional notes:
<!-- Any extra context, screenshots, or information for the reviewer -->
- N/A

## ✅ PR Checklist
- [x] No sensitive information (passwords, API keys, secrets) exposed
- [x] All tests run and pass successfully (unit, e2e, lint, etc.)
- [x] Code compiles and runs without errors
- [x] Tests and documentation updated or added if applicable
- [x] Removed unnecessary comments, debug statements and dev artifacts
- [x] Related issues, labels, and PR links established; PR title OK